### PR TITLE
Fix reverse orientation for last gene in a design in renderDNA

### DIFF
--- a/dnaplotlib/dnaplotlib.py
+++ b/dnaplotlib/dnaplotlib.py
@@ -2290,6 +2290,12 @@ class DNARenderer:
             if 'type' in keys:
                 if 'fwd' not in keys:
                     part['fwd'] = True
+                else:
+                    if part['fwd'] == False:
+                        start = part['start']
+                        end = part['end']
+                        part['end'] = start
+                        part['start'] = end
                 if 'start' not in keys:
                     if part['fwd'] == True:
                         part['start'] = part_num


### PR DESCRIPTION
When rendering the last gene in a design, it would not be reversed if 'fwd' == False. This addition checks for 'fwd' == False and renders the reversed orientation of the part.